### PR TITLE
Maintain Suspend and PowerOff buttons connect() methods for Gnome3.26

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -2,18 +2,29 @@
 
 const Main = imports.ui.main;
 const Lang = imports.lang;
+const GObject = imports.gi.GObject;
+const BoxPointer = imports.ui.boxpointer;
 
 let menu, item, suspendAction, powerOffAction;
+let bindFlags = GObject.BindingFlags.DEFAULT | GObject.BindingFlags.SYNC_CREATE;
 
 function init() {
     menu = Main.panel.statusArea['aggregateMenu']._system;
     item = menu._actionsItem;
 
     suspendAction = menu._createActionButton('media-playback-pause-symbolic', _("Suspend"));
-    suspendAction.connect('clicked', Lang.bind(menu, menu._onSuspendClicked));
+    suspendAction.connect('clicked', () => {
+        menu.menu.itemActivated(BoxPointer.PopupAnimation.NONE);
+        menu._systemActions.activateSuspend();
+    });
+    menu._systemActions.bind_property('can-suspend', suspendAction, 'visible', bindFlags);
 
     powerOffAction = menu._createActionButton('system-shutdown-symbolic', _("Power Off"));
-    powerOffAction.connect('clicked', Lang.bind(menu, menu._onPowerOffClicked));
+    powerOffAction.connect('clicked', () => {
+        menu.menu.itemActivated(BoxPointer.PopupAnimation.NONE);
+        menu._systemActions.activatePowerOff();
+    });
+    menu._systemActions.bind_property('can-power-off', powerOffAction, 'visible', bindFlags);
 }
 
 function enable() {


### PR DESCRIPTION
Update `suspendAction` and `powerOffAction` objects `connect()` methods according to latest Gnome Shell commits in [gnome-shell/js/ui/status/system.js](https://github.com/GNOME/gnome-shell/commits/master/js/ui/status/system.js) file.
Then binds updated objects with `_systemActions`.

It fixes issue #2 for Gnome 3.26 release.